### PR TITLE
Fix loophole for defaultValue fragments not being updated correctly on error

### DIFF
--- a/addon/attributes/fragment.js
+++ b/addon/attributes/fragment.js
@@ -92,6 +92,7 @@ export default function fragment(type, options) {
         const fragment = isFragment(defaultValue) ? defaultValue : this.store.createFragment(actualType, defaultValue);
         setFragmentOwner(fragment, recordData, key);
         recordData._fragmentData[key] = recordDataFor(fragment);
+        recordData._fragments[key] = recordDataFor(fragment);
         return fragment;
       }
       const fragment = recordData.getFragment(key);

--- a/tests/integration/save_test.js
+++ b/tests/integration/save_test.js
@@ -933,6 +933,35 @@ module('integration - Persistence', function(hooks) {
     });
   });
 
+  test('commitwasrejected is called properly after failed save on default', function(assert) {
+    // assert.expect(3);
+
+    let Address = MF.Fragment.extend({
+      line1: attr('string'),
+      line2: attr('string')
+    });
+
+    owner.register('model:address', Address);
+
+    let DefaultAddressPerson = Model.extend({
+      address: MF.fragment('address', {
+        defaultValue() {
+          return {};
+        }
+      })
+    });
+
+    owner.register('model:default-address-person', DefaultAddressPerson);
+
+    return run(() => {
+      let p = store.createRecord('default-address-person');
+      let address = p.get('address');
+      return p.save().catch(() => {
+        assert.equal(address._internalModel.currentState.stateName, 'root.loaded.created.uncommitted');
+      });
+    });
+  });
+
   test('setting an array does not error on save', function() {
     let Army = Model.extend({
       soldiers: MF.array('string')


### PR DESCRIPTION
`willCommit` looks for values in `this._fragments`, but this value was never set in `this._fragments` when a defaultValue was used. 